### PR TITLE
number field quadratic: fixing test and specifying rounding mode in the doc

### DIFF
--- a/src/sage/rings/number_field/number_field_element_quadratic.pyx
+++ b/src/sage/rings/number_field/number_field_element_quadratic.pyx
@@ -2310,7 +2310,7 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
 
     def round(self):
         r"""
-        Returns the round (nearest integer).
+        Returns the round (nearest integer, away from zero in case of ties).
 
         EXAMPLES::
 
@@ -2332,9 +2332,9 @@ cdef class NumberFieldElement_quadratic(NumberFieldElement_absolute):
             sage: for _ in range(100):
             ....:    a = QQ.random_element(1000,20)
             ....:    b = QQ.random_element(1000,20)
-            ....:    assert round(a) == round(K2(a)), a
-            ....:    assert round(a) == round(K3(a)), a
-            ....:    assert round(a) == round(K5(a)), a
+            ....:    assert a.round("away") == round(K2(a)), a
+            ....:    assert a.round("away") == round(K3(a)), a
+            ....:    assert a.round("away") == round(K5(a)), a
             ....:    assert round(a+b*sqrt(2.)) == round(a+b*sqrt2), (a, b)
             ....:    assert round(a+b*sqrt(3.)) == round(a+b*sqrt3), (a, b)
             ....:    assert round(a+b*sqrt(5.)) == round(a+b*sqrt5), (a, b)


### PR DESCRIPTION
This fixes the testing error. The existing rounding mode for quadratic number field is kept as such (away from zero, now specified in the doc). The test is modified to take the change in rational's rounding mode into account.